### PR TITLE
Store the MFA in swarm_registry for remote entries

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -998,7 +998,7 @@ defmodule Swarm.Tracker do
               debug "#{inspect name} already registered to #{inspect pid} on #{remote_node}, but missing locally"
               ref = Process.monitor(pid)
               lclock = Clock.peek(state.clock)
-              :ets.insert(:swarm_registry, entry(name: name, pid: pid, ref: ref, meta: %{}, clock: lclock))
+              :ets.insert(:swarm_registry, entry(name: name, pid: pid, ref: ref, meta: %{mfa: {m,f,a}}, clock: lclock))
               {:ok, pid}
             entry(pid: ^pid) ->
               debug "#{inspect name} already registered to #{inspect pid} on #{remote_node}"


### PR DESCRIPTION
As discussed in IRC, remote processes are not registered with the MFA and are not restarted.