### PR TITLE
Use slave module for easy cluster tests

### DIFF
--- a/bench/tracker.exs
+++ b/bench/tracker.exs
@@ -16,10 +16,10 @@ end
 
 # Best single-node run so far 470ms for 10k
 Benchee.run(%{time: 10}, %{
-      "Swarm.register_name/4" => fn ->
-        for i <- 1..10_000 do
-          r = :rand.uniform(100_000_000)
-          {:ok, _pid} = Swarm.register_name({:myapp, i, r}, SwarmTest.Worker, :start_link, [])
-        end
-      end
+  "Swarm.register_name/4" => fn ->
+    for i <- 1..10_000 do
+      r = :rand.uniform(100_000_000)
+      {:ok, _pid} = Swarm.register_name({:myapp, i, r}, SwarmTest.Worker, :start_link, [])
+    end
+  end
 })

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,10 +1,13 @@
 use Mix.Config
 
 config :swarm,
-  debug: true,   # turn on debugging mode
+  nodes: [:"node1@127.0.0.1", :"node2@127.0.0.1"],
+  sync_nodes_timeout: 0,
+  debug: false,
   node_blacklist: [
     # the following blacklists nodes set up by exrm/relx/distillery
     # for remote shells (the first) and hot upgrade scripting (the second)
+    ~r/^primary@.+$/,
     ~r/^remsh.*$/,
     ~r/^.+_upgrader_.+$/
     # or using strings..
@@ -16,7 +19,7 @@ config :swarm,
   ]
 
 config :logger,
-  level: :debug
+  level: :info
 
 config :porcelain,
   goon_warn_if_missing: false

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,0 +1,64 @@
+defmodule Swarm.IntegrationTest do
+  use Swarm.NodeCase
+
+  @primary :"primary@127.0.0.1"
+  @node1 :"node1@127.0.0.1"
+  @node2 :"node2@127.0.0.1"
+  @worker_count 10
+
+  test "correct redistribution of processes" do
+    for n <- 1..@worker_count do
+      {_, {:ok, _}} = spawn_worker(@node1, {:worker, n})
+    end
+
+    node1_registry = get_registry(@node1)
+    node2_registry = get_registry(@node2)
+
+    # each node should have a all workers in their registry
+    assert length(node1_registry) == @worker_count
+    assert length(node2_registry) == @worker_count
+
+    assert length(workers_for(@node1)) < @worker_count
+    assert length(workers_for(@node2)) < @worker_count
+
+    # netsplit
+    disconnect(@node1, from: @node2)
+
+    # wait for process redistribution
+    Process.sleep(@worker_count)
+
+    ## check to see if the processes were migrated as expected
+    assert length(workers_for(@node1)) == @worker_count
+    assert length(workers_for(@node2)) == @worker_count
+
+    # restore the cluster
+    connect(@node1, to: @node2)
+
+    # give time to sync
+    Process.sleep(@worker_count)
+
+    # make sure processes are back in the correct place
+    assert length(workers_for(@node1)) < @worker_count
+    assert length(workers_for(@node2)) < @worker_count
+  end
+
+  defp disconnect(node, opts) do
+    from = Keyword.fetch!(opts, :from)
+    :rpc.call(node, Node, :disconnect, [from])
+  end
+
+  defp connect(node, opts) do
+    to = Keyword.fetch!(opts, :to)
+    :rpc.call(node, Node, :connect, [to])
+  end
+
+  defp get_registry(node) do
+    :rpc.call(node, Swarm, :registered, [], :infinity)
+  end
+
+  defp workers_for(node) do
+    node
+    |> get_registry()
+    |> Enum.filter(fn {_, pid} -> node(pid) == node end)
+  end
+end

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,0 +1,68 @@
+defmodule Swarm.Cluster do
+
+  def spawn do
+    # Turn node into a distributed node with the given long name
+    :net_kernel.start([:"primary@127.0.0.1"])
+
+    # Allow spawned nodes to fetch all code from this node
+    :erl_boot_server.start([])
+    allow_boot to_char_list("127.0.0.1")
+
+    nodes = Application.get_env(:swarm, :nodes, [])
+
+    :ok = Application.load(:swarm)
+
+    nodes
+    |> Enum.map(&Task.async(fn -> spawn_node(&1) end))
+    |> Enum.map(&Task.await(&1, 30_000))
+  end
+
+  defp spawn_node(node_host) do
+    {:ok, node} = :slave.start(to_char_list("127.0.0.1"), node_name(node_host), inet_loader_args())
+    add_code_paths(node)
+    transfer_configuration(node)
+    ensure_applications_started(node)
+    {:ok, node}
+  end
+
+  defp rpc(node, module, fun, args) do
+    :rpc.block_call(node, module, fun, args)
+  end
+
+  defp inet_loader_args do
+    to_char_list("-loader inet -hosts 127.0.0.1 -setcookie #{:erlang.get_cookie()}")
+  end
+
+  defp allow_boot(host) do
+    {:ok, ipv4} = :inet.parse_ipv4_address(host)
+    :erl_boot_server.add_slave(ipv4)
+  end
+
+  defp add_code_paths(node) do
+    rpc(node, :code, :add_paths, [:code.get_path()])
+  end
+
+  defp transfer_configuration(node) do
+    for {app_name, _, _} <- Application.loaded_applications do
+      for {key, val} <- Application.get_all_env(app_name) do
+        rpc(node, Application, :put_env, [app_name, key, val])
+      end
+    end
+  end
+
+  defp ensure_applications_started(node) do
+    rpc(node, Application, :ensure_all_started, [:mix])
+    rpc(node, Mix, :env, [Mix.env()])
+    for {app_name, _, _} <- Application.loaded_applications do
+      rpc(node, Application, :ensure_all_started, [app_name])
+    end
+  end
+
+  defp node_name(node_host) do
+    node_host
+    |> to_string
+    |> String.split("@")
+    |> Enum.at(0)
+    |> String.to_atom
+  end
+end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,0 +1,58 @@
+defmodule Swarm.NodeCase do
+  @timeout 5000
+  @heartbeat 100
+  @permdown 1500
+
+  defmacro __using__(_opts) do
+    quote do
+      use ExUnit.Case, async: true
+      import unquote(__MODULE__)
+      @moduletag :clustered
+
+      @timeout unquote(@timeout)
+      @heartbeat unquote(@heartbeat)
+      @permdown unquote(@permdown)
+    end
+  end
+
+  def start_tracker(node) do
+    call_node(node, fn ->
+      {:ok, result} = Application.ensure_all_started(:swarm)
+      result
+    end)
+  end
+
+  def spawn_worker(node, name) do
+    call_node(node, fn ->
+      Swarm.register_name(name, MyApp.Worker, :start_link, [])
+    end)
+  end
+
+  def flush() do
+    receive do
+      _ -> flush()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp call_node(node, func) do
+    parent = self()
+    ref = make_ref()
+
+    pid = Node.spawn_link(node, fn ->
+      result = func.()
+      send parent, {ref, result}
+      ref = Process.monitor(parent)
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      end
+    end)
+
+    receive do
+      {^ref, result} -> {pid, result}
+    after
+      @timeout -> {pid, {:error, :timeout}}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,7 @@
+exclude = Keyword.get(ExUnit.configuration(), :exclude, [])
+
+unless :clustered in exclude do
+  Swarm.Cluster.spawn()
+end
+
 ExUnit.start()


### PR DESCRIPTION
Practically all the support code was stolen from Phoenix.PubSub test suite.

This PR utilizes the `:slave` module to spawn 2 nodes that run the swarm application.

More to come...