### PR TITLE
Do not consider pid node down if it is us

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -724,8 +724,9 @@ defmodule Swarm.Tracker do
             end
         end
       entry(name: name, pid: pid) = obj, lclock ->
+        pid_node = node(pid)
         cond do
-          Enum.member?(state.nodes, node(pid)) ->
+          state.self == pid_node or Enum.member?(state.nodes, pid_node) ->
             # the parent node is still up
             lclock
           :else ->


### PR DESCRIPTION
Was getting issues where existing registrations on a single node were lost if another one connected. Tracked it down to this line, and this "fixes" it, but I'm not sure this is right.