### PR TITLE
Static quorum ring distribution strategy

### DIFF
--- a/lib/swarm.ex
+++ b/lib/swarm.ex
@@ -40,6 +40,7 @@ defmodule Swarm do
   You can optionally provide a `:timeout` value to limit the duration of blocking calls.
   The default value is `:infinity` to block indefinitely.
   """
+  @spec register_name(term, atom(), atom(), [term]) :: {:ok, pid} | {:error, term}
   @spec register_name(term, atom(), atom(), [term], non_neg_integer() | :infinity) :: {:ok, pid} | {:error, term}
   def register_name(name, m, f, a, timeout \\ :infinity)
   def register_name(name, m, f, a, timeout), do: Swarm.Registry.register(name, m, f, a, timeout)

--- a/lib/swarm.ex
+++ b/lib/swarm.ex
@@ -42,9 +42,7 @@ defmodule Swarm do
   """
   @spec register_name(term, atom(), atom(), [term], non_neg_integer() | :infinity) :: {:ok, pid} | {:error, term}
   def register_name(name, m, f, a, timeout \\ :infinity)
-  def register_name(name, m, f, a, timeout) do
-    Swarm.Registry.register(name, m, f, a, timeout)
-  end
+  def register_name(name, m, f, a, timeout), do: Swarm.Registry.register(name, m, f, a, timeout)
 
   @doc """
   Unregisters the given name from the registry.

--- a/lib/swarm.ex
+++ b/lib/swarm.ex
@@ -36,9 +36,15 @@ defmodule Swarm do
   This version also returns an ok tuple with the pid if it registers successfully,
   or an error tuple if registration fails. You cannot use this with processes which
   are already started, it must be started by `:swarm`.
+
+  You can optionally provide a `:timeout` value to limit the duration of blocking calls.
+  The default value is `:infinity` to block indefinitely.
   """
-  @spec register_name(term, atom(), atom(), [term]) :: {:ok, pid} | {:error, term}
-  defdelegate register_name(name, m, f, a), to: Swarm.Registry, as: :register
+  @spec register_name(term, atom(), atom(), [term], non_neg_integer() | :infinity) :: {:ok, pid} | {:error, term}
+  def register_name(name, m, f, a, timeout \\ :infinity)
+  def register_name(name, m, f, a, timeout) do
+    Swarm.Registry.register(name, m, f, a, timeout)
+  end
 
   @doc """
   Unregisters the given name from the registry.

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -31,11 +31,10 @@ defmodule Swarm.Distribution.StaticQuorumRing do
 
   alias Swarm.Distribution.StaticQuorumRing
 
-  defstruct [:node_count, :static_quorum_size, :ring]
+  defstruct [:static_quorum_size, :ring]
 
   def create do
     %StaticQuorumRing{
-      node_count: 0,
       static_quorum_size: Application.get_env(:swarm, :static_quorum_size, 2),
       ring: HashRing.new(),
     }
@@ -43,28 +42,24 @@ defmodule Swarm.Distribution.StaticQuorumRing do
 
   def add_node(quorum, node) do
     %StaticQuorumRing{quorum |
-      node_count: quorum.node_count + 1,
       ring: HashRing.add_node(quorum.ring, node),
     }
   end
 
   def add_node(quorum, node, weight) do
     %StaticQuorumRing{quorum |
-      node_count: quorum.node_count + 1,
       ring: HashRing.add_node(quorum.ring, node, weight),
     }
   end
 
   def add_nodes(quorum, nodes) do
     %StaticQuorumRing{quorum |
-      node_count: quorum.node_count + length(nodes),
       ring: HashRing.add_nodes(quorum.ring, nodes),
     }
   end
 
   def remove_node(quorum, node) do
     %StaticQuorumRing{quorum |
-      node_count: quorum.node_count - 1,
       ring: HashRing.remove_node(quorum.ring, node),
     }
   end
@@ -74,10 +69,10 @@ defmodule Swarm.Distribution.StaticQuorumRing do
 
   If the available nodes in the cluster are fewer than the minimum node count it returns `:undefined`.
   """
-  def key_to_node(%StaticQuorumRing{static_quorum_size: static_quorum_size} = quorum, key) do
-    case quorum.node_count do
-      count when count < static_quorum_size -> :undefined
-      _ -> HashRing.key_to_node(quorum.ring, key)
+  def key_to_node(%StaticQuorumRing{static_quorum_size: static_quorum_size, ring: ring}, key) do
+    case length(ring.nodes) do
+      node_count when node_count < static_quorum_size -> :undefined
+      _ -> HashRing.key_to_node(ring, key)
     end
   end
 end

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -5,9 +5,10 @@ defmodule Swarm.Distribution.StaticQuorumRing do
 
   ## Quorum size
 
-  You must configure the quorum size using the `:static_quorum_size` setting:
+  You must configure the distribution strategy and its quorum size using the `:static_quorum_size` setting:
 
       config :swarm,
+        distribution_strategy: Swarm.Distribution.StaticQuorumRing,
         static_quorum_size: 5
 
   It defines the minimum number of nodes that must be connected in the cluster to allow process
@@ -16,9 +17,24 @@ defmodule Swarm.Distribution.StaticQuorumRing do
   If there are fewer nodes currently available than the quorum size, any calls to
   `Swarm.register_name/5` will block until enough nodes have started.
 
-  As an example, in a 9 node cluster you would configure the `:static_quorum_size` as 5. If there
-  is a network split of 4 and 5 nodes, processes on the side with 5 nodes will continue running but
-  processes on the other 4 nodes will be stopped.
+  You can configure the `:kernel` application to wait for cluster formation before starting your
+  application during node start up. The `sync_nodes_optional` configuration specifies which nodes
+  to attempt to connect to within the `sync_nodes_timeout` window, defined in milliseconds, before
+  continuing with startup. There is also a `sync_nodes_mandatory` setting which can be used to
+  enforce all nodes are connected within the timeout window or else the node terminates.
+
+      config :kernel,
+        sync_nodes_optional: [:"node1@192.168.1.1", :"node2@192.168.1.2"],
+        sync_nodes_timeout: 60_000
+
+  The `sync_nodes_timeout` can be configured as `:infinity` to wait indefinitely for all nodes to
+  connect. All involved nodes must have the same value for `sync_nodes_timeout`.
+
+  ### Example
+
+  In a 9 node cluster you would configure the `:static_quorum_size` as 5. If there is a network split
+  of 4 and 5 nodes, processes on the side with 5 nodes will continue running but processes on the
+  other 4 nodes will be stopped.
 
   Be aware that in the running 5 node cluster, no more failures can be handled because the
   remaining cluster size would be less than 5. In the case of another failure in that 5 node

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -1,9 +1,7 @@
 defmodule Swarm.Distribution.StaticQuorumRing do
   @moduledoc """
   A quorum is the minimum number of nodes that a distributed cluster has to obtain in order to be
-  allowed to perform an operation in a distributed system.
-
-  Used to enforce consistent operation in a distributed system.
+  allowed to perform an operation. This can be used to enforce consistent operation in a distributed system.
 
   ## Quorum size
 
@@ -16,13 +14,13 @@ defmodule Swarm.Distribution.StaticQuorumRing do
   registration and distribution.
 
   If there are fewer nodes currently available than the quorum size, any calls to
-  `Swarm.register_name/3` will block until enough nodes have started.
+  `Swarm.register_name/5` will block until enough nodes have started.
 
   As an example, in a 9 node cluster you would configure the `:static_quorum_size` as 5. If there
   is a network split of 4 and 5 nodes, processes on the side with 5 nodes will continue running but
   processes on the other 4 nodes will be stopped.
 
-  Be aware that in the running 5 node cluster, no more failures can be handled, because the
+  Be aware that in the running 5 node cluster, no more failures can be handled because the
   remaining cluster size would be less than 5. In the case of another failure in that 5 node
   cluster all running processes will be stopped.
   """

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -4,18 +4,39 @@ defmodule Swarm.Distribution.StaticQuorumRing do
   allowed to perform an operation in a distributed system.
 
   Used to enforce consistent operation in a distributed system.
+
+  ## Quorum size
+
+  You must configure the quorum size using the `:static_quorum_size` setting:
+
+      config :swarm,
+        static_quorum_size: 5
+
+  It defines the minimum number of nodes that must be connected in the cluster to allow process
+  registration and distribution.
+
+  If there are fewer nodes currently available than the quorum size, any calls to
+  `Swarm.register_name/3` will block until enough nodes have started.
+
+  As an example, in a 9 node cluster you would configure the `:static_quorum_size` as 5. If there
+  is a network split of 4 and 5 nodes, processes on the side with 5 nodes will continue running but
+  processes on the other 4 nodes will be stopped.
+
+  Be aware that in the running 5 node cluster, no more failures can be handled, because the
+  remaining cluster size would be less than 5. In the case of another failure in that 5 node
+  cluster all running processes will be stopped.
   """
 
   use Swarm.Distribution.Strategy
 
   alias Swarm.Distribution.StaticQuorumRing
 
-  defstruct [:node_count, :min_node_count, :ring]
+  defstruct [:node_count, :static_quorum_size, :ring]
 
   def create do
     %StaticQuorumRing{
       node_count: 0,
-      min_node_count: Application.get_env(:swarm, :min_quorum_node_size, 2),
+      static_quorum_size: Application.get_env(:swarm, :static_quorum_size, 2),
       ring: HashRing.new(),
     }
   end
@@ -53,9 +74,9 @@ defmodule Swarm.Distribution.StaticQuorumRing do
 
   If the available nodes in the cluster are fewer than the minimum node count it returns `:undefined`.
   """
-  def key_to_node(%StaticQuorumRing{min_node_count: min_node_count} = quorum, key) do
+  def key_to_node(%StaticQuorumRing{static_quorum_size: static_quorum_size} = quorum, key) do
     case quorum.node_count do
-      count when count < min_node_count -> :undefined
+      count when count < static_quorum_size -> :undefined
       _ -> HashRing.key_to_node(quorum.ring, key)
     end
   end

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -1,0 +1,57 @@
+defmodule Swarm.Distribution.StaticQuorumRing do
+  @moduledoc """
+  A quorum is the minimum number of votes that a distributed cluster has to obtain in order to be
+  allowed to perform an operation in a distributed system.
+
+  Used to enforce consistent operation in a distributed system.
+  """
+
+  use Swarm.Distribution.Strategy
+
+  alias Swarm.Distribution.StaticQuorumRing
+
+  defstruct [:node_count, :min_node_count, :ring]
+
+  def create do
+    %StaticQuorumRing{
+      node_count: 0,
+      min_node_count: Application.get_env(:swarm, :min_quorum_node_size, 2),
+      ring: HashRing.new(),
+    }
+  end
+
+  def add_node(quorum, node) do
+    %StaticQuorumRing{quorum |
+      node_count: quorum.node_count + 1,
+      ring: HashRing.add_node(quorum.ring, node),
+    }
+  end
+
+  def add_node(quorum, node, weight) do
+    %StaticQuorumRing{quorum |
+      node_count: quorum.node_count + 1,
+      ring: HashRing.add_node(quorum.ring, node, weight),
+    }
+  end
+
+  def add_nodes(quorum, nodes) do
+    %StaticQuorumRing{quorum |
+      node_count: quorum.node_count + length(nodes),
+      ring: HashRing.add_nodes(quorum.ring, nodes),
+    }
+  end
+
+  def remove_node(quorum, node) do
+    %StaticQuorumRing{quorum |
+      node_count: quorum.node_count - 1,
+      ring: HashRing.remove_node(quorum.ring, node),
+    }
+  end
+
+  def key_to_node(%StaticQuorumRing{min_node_count: min_node_count} = quorum, key) do
+    case quorum.node_count do
+      count when count < min_node_count -> :undefined
+      _ -> HashRing.key_to_node(quorum.ring, key)
+    end
+  end
+end

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -48,6 +48,11 @@ defmodule Swarm.Distribution.StaticQuorumRing do
     }
   end
 
+  @doc """
+  Maps a key to a specific node via the current distribution strategy.
+
+  If the available nodes in the cluster are fewer than the minimum node count it returns `:undefined`.
+  """
   def key_to_node(%StaticQuorumRing{min_node_count: min_node_count} = quorum, key) do
     case quorum.node_count do
       count when count < min_node_count -> :undefined

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -1,6 +1,6 @@
 defmodule Swarm.Distribution.StaticQuorumRing do
   @moduledoc """
-  A quorum is the minimum number of votes that a distributed cluster has to obtain in order to be
+  A quorum is the minimum number of nodes that a distributed cluster has to obtain in order to be
   allowed to perform an operation in a distributed system.
 
   Used to enforce consistent operation in a distributed system.

--- a/lib/swarm/distribution/strategy.ex
+++ b/lib/swarm/distribution/strategy.ex
@@ -13,7 +13,7 @@ defmodule Swarm.Distribution.Strategy do
   process for storing the distribution state, because it has the potential to become a bottleneck otherwise,
   however this is really up to the needs of your situation, just know that you can go either way.
   """
-  alias Swarm.Distribution.Strategy.Ring, as: RingStrategy
+  alias Swarm.Distribution.Ring, as: RingStrategy
 
   defmacro __using__(_) do
     quote do

--- a/lib/swarm/distribution/strategy.ex
+++ b/lib/swarm/distribution/strategy.ex
@@ -34,7 +34,7 @@ defmodule Swarm.Distribution.Strategy do
   @callback add_node(strategy, node, weight) :: strategy | {:error, reason}
   @callback add_nodes(strategy, nodelist) :: strategy | {:error, reason}
   @callback remove_node(strategy, node) :: strategy | {:error, reason}
-  @callback key_to_node(strategy, key) :: node()
+  @callback key_to_node(strategy, key) :: node() | :undefined
 
   def create(), do: strategy_module().create()
   def create(node), do: strategy_module().add_node(create(), node)

--- a/lib/swarm/registry.ex
+++ b/lib/swarm/registry.ex
@@ -9,7 +9,7 @@ defmodule Swarm.Registry do
   ## Public API
 
   defdelegate register(name, pid), to: Tracker, as: :track
-  defdelegate register(name, module, fun, args), to: Tracker, as: :track
+  defdelegate register(name, module, fun, args, timeout), to: Tracker, as: :track
 
   @spec unregister(term) :: :ok
   def unregister(name) do

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1196,6 +1196,10 @@ defmodule Swarm.Tracker do
             nil -> :ok
             _   -> GenStateMachine.reply(from, {:ok, pid})
           end
+        {:error, {:noproc, _}} = err ->
+          warn "#{inspect name} could not be started on #{remote_node}: #{inspect err}, retrying operation after 1s.."
+          :timer.sleep 1_000
+          start_pid_remotely(remote_node, from, name, m, f, a, state)
         {:error, _reason} = err when from != nil ->
           warn "#{inspect name} could not be started on #{remote_node}: #{inspect err}"
           GenStateMachine.reply(from, err)

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -779,7 +779,7 @@ defmodule Swarm.Tracker do
         end
     end)
 
-    GenStateMachine.cast(self(), {:retry_pending_trackings})
+    GenStateMachine.cast(__MODULE__, {:retry_pending_trackings})
 
     info "topology change complete"
     {:keep_state, %{state | clock: new_clock}}
@@ -991,7 +991,7 @@ defmodule Swarm.Tracker do
     add_registration({name, pid, meta}, from, state)
   end
   defp handle_call({:track, name, m, f, a}, from, state) do
-    current_node = Node.self
+    current_node = Node.self()
     case from do
       {from_pid, _} when node(from_pid) != current_node ->
         debug "#{inspect node(from_pid)} is registering #{inspect name} as process started by #{m}.#{f}/#{length(a)} with args #{inspect a}"
@@ -1164,8 +1164,8 @@ defmodule Swarm.Tracker do
         end
 
       remote_node ->
+        debug "starting #{inspect name} on remote node #{remote_node}"
         {:ok, _pid} = Task.start(fn ->
-          debug "starting #{inspect name} on #{remote_node}"
           start_pid_remotely(remote_node, from, name, m, f, a, state)
         end)
         :keep_state_and_data

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -725,11 +725,9 @@ defmodule Swarm.Tracker do
                   debug "#{inspect name} has requested to be restarted"
                   {:ok, new_state} = remove_registration(obj, %{state | clock: lclock})
                   send(pid, {:swarm, :die})
-                  case handle_call({:track, name, m, f, a}, nil, %{state | clock: lclock}) do
-                    :keep_state_and_data ->
-                      new_state.clock
-                    {:keep_state, new_state} ->
-                      new_state.clock
+                  case do_track(%Tracking{name: name, m: m, f: f, a: a}, %{state | clock: lclock}) do
+                    :keep_state_and_data ->     new_state.clock
+                    {:keep_state, new_state} -> new_state.clock
                   end
               end
             catch
@@ -756,11 +754,9 @@ defmodule Swarm.Tracker do
               ^current_node ->
                 debug "restarting #{inspect name} on #{current_node}"
                 {:ok, new_state} = remove_registration(obj, %{state | clock: lclock})
-                case handle_call({:track, name, m, f, a}, nil, new_state) do
-                  :keep_state_and_data ->
-                    new_state.clock
-                  {:keep_state, new_state} ->
-                    new_state.clock
+                case do_track(%Tracking{name: name, m: m, f: f, a: a}, new_state) do
+                  :keep_state_and_data ->     new_state.clock
+                  {:keep_state, new_state} -> new_state.clock
                 end
               _other_node ->
                 # other_node will tell us to unregister/register the restarted pid
@@ -1099,7 +1095,7 @@ defmodule Swarm.Tracker do
           ^current_node ->
             debug "restarting #{inspect name} (#{inspect pid}) on #{current_node}"
             {:ok, new_state} = remove_registration(obj, state)
-            handle_call({:track, name, m, f, a}, nil, new_state)
+            do_track(%Tracking{name: name, m: m, f: f, a: a}, new_state)
           other_node ->
             debug "#{inspect name} (#{inspect pid}) is owned by #{other_node}, skipping"
             {:ok, new_state} = remove_registration(obj, state)

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Swarm.Mixfile do
   def project do
     [app: :swarm,
      version: "3.0.5",
-     elixir: "~> 1.5",
+     elixir: "~> 1.3",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Swarm.Mixfile do
   def project do
     [app: :swarm,
      version: "3.0.5",
-     elixir: "~> 1.3",
+     elixir: "~> 1.5",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -31,7 +31,7 @@ defmodule Swarm.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :crypto, :libring, :gen_state_machine],
+    [extra_applications: [:logger, :crypto],
      mod: {Swarm, []}]
   end
 

--- a/test/distribution/static_quorum_ring_test.exs
+++ b/test/distribution/static_quorum_ring_test.exs
@@ -1,0 +1,21 @@
+defmodule Swarm.Distribution.StaticQuorumRingTests do
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Swarm.Distribution.StaticQuorumRing
+
+  test "key to node should return `:undefined` until quorum size reached" do
+    quorum =
+      StaticQuorumRing.create()
+      |> StaticQuorumRing.add_node("node1")
+
+    assert StaticQuorumRing.key_to_node(quorum, :key1) == :undefined
+
+    quorum = StaticQuorumRing.add_node(quorum, "node2")
+    assert StaticQuorumRing.key_to_node(quorum, :key1) != :undefined
+
+    quorum = StaticQuorumRing.add_node(quorum, "node3")
+    assert StaticQuorumRing.key_to_node(quorum, :key1) != :undefined
+  end
+end

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -3,7 +3,7 @@ defmodule Swarm.QuorumTests do
 
   @moduletag :capture_log
 
-  alias Swarm.Distribution.StaticQuorumRing
+  alias Swarm.Distribution.{Ring,StaticQuorumRing}
 
   setup_all do
     :rand.seed(:exs64)
@@ -14,31 +14,23 @@ defmodule Swarm.QuorumTests do
     {:ok, _} = MyApp.WorkerSup.start_link()
 
     on_exit fn ->
-      restart_cluster_using_strategy(RingStrategy)
+      restart_cluster_using_strategy(Ring)
     end
 
     :ok
   end
 
-  test "block until quorum size reached" do
-    quorum =
-      StaticQuorumRing.create()
-      |> StaticQuorumRing.add_node("node1")
-      |> StaticQuorumRing.add_node("node2")
-
-    assert StaticQuorumRing.key_to_node(quorum, :key1) == :undefined
-
-    quorum = StaticQuorumRing.add_node(quorum, "node3")
-
-    assert StaticQuorumRing.key_to_node(quorum, :key1) != :undefined
+  setup do
+    on_exit fn ->
+      Swarm.Cluster.stop_node(:"node3@127.0.0.1")
+    end
   end
 
-  @tag :wip
-  test "block track until quorum size reached" do
+  test "block name registration until quorum size reached" do
     reply_to = self()
 
     registration = Task.async(fn ->
-      {:ok, pid1} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+      {:ok, _pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
 
       send(reply_to, :tracked)
     end)
@@ -46,7 +38,7 @@ defmodule Swarm.QuorumTests do
     refute_receive(:tracked)
 
     # add third node to cluster, meeting min quorum requirements
-    Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+    {:ok, _node} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
 
     # register name should now succeed
     Task.await(registration, 5_000)
@@ -54,10 +46,49 @@ defmodule Swarm.QuorumTests do
     assert_receive(:tracked)
   end
 
+  describe "with quorum cluster" do
+    setup [:start_third_node]
+
+    test "kill process after topology change results in no available node to host", %{node3: node3} do
+      {:ok, pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+
+      ref = Process.monitor(pid)
+
+      # stopping node3 means not enough needs for a quorum, running processes must be stopped
+      Swarm.Cluster.stop_node(node3)
+
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end
+
+    test "restart a killed process after topology change restores min quorum", %{node3: node3} do
+      {:ok, pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+
+      ref = Process.monitor(pid)
+
+      # stopping node3 means not enough needs for a quorum, running processes must be stopped
+      Swarm.Cluster.stop_node(node3)
+      assert_receive {:DOWN, ^ref, _, _, _}
+
+      # restore third node to cluster, meeting min quorum requirements
+      {:ok, _node3} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+
+      assert Swarm.whereis_name({:test, 1}) != :undefined
+    end
+
+    # add third node to cluster, meeting min quorum requirements
+    defp start_third_node(_context) do
+      {:ok, node3} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+
+      [node3: node3]
+    end
+  end
+
   defp restart_cluster_using_strategy(strategy) do
     Swarm.Cluster.stop()
 
     Application.put_env(:swarm, :distribution_strategy, strategy)
+
+    Application.stop(:swarm)
 
     Swarm.Cluster.spawn()
 

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -3,18 +3,27 @@ defmodule Swarm.QuorumTests do
 
   @moduletag :capture_log
 
+  @node1 :"node1@127.0.0.1"
+  @node2 :"node2@127.0.0.1"
+  @node3 :"node3@127.0.0.1"
+  @node4 :"node4@127.0.0.1"
+  @node5 :"node5@127.0.0.1"
+  @nodes [@node1, @node2, @node3, @node4, @node5]
+
+  alias Swarm.Cluster
   alias Swarm.Distribution.{Ring,StaticQuorumRing}
 
   setup_all do
     :rand.seed(:exs64)
 
     Application.put_env(:swarm, :static_quorum_size, 3)
-    restart_cluster_using_strategy(StaticQuorumRing)
+    restart_cluster_using_strategy(StaticQuorumRing, [])
 
     {:ok, _} = MyApp.WorkerSup.start_link()
 
     on_exit fn ->
-      restart_cluster_using_strategy(Ring)
+      nodes = Application.get_env(:swarm, :nodes, [])
+      restart_cluster_using_strategy(Ring, nodes)
     end
 
     :ok
@@ -22,75 +31,179 @@ defmodule Swarm.QuorumTests do
 
   setup do
     on_exit fn ->
-      Swarm.Cluster.stop_node(:"node3@127.0.0.1")
+      # stop any started nodes after each test
+      @nodes
+      |> Enum.map(&Task.async(fn -> Cluster.stop_node(&1) end))
+      |> Enum.map(&Task.await(&1, 30_000))
     end
   end
 
-  test "block name registration until quorum size reached" do
-    reply_to = self()
+  describe "without quorum cluster" do
+    setup [:form_two_node_cluster]
 
-    registration = Task.async(fn ->
-      {:ok, _pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+    test "block name registration until quorum size reached" do
+      registration = Task.async(fn ->
+        register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
+      end)
 
-      send(reply_to, :tracked)
-    end)
+      # ensure registration is blocked, and procoess not yet started/registered
+      assert get_registry(@node1) == []
 
-    refute_receive(:tracked)
+      # add third node to cluster, meeting min quorum requirements
+      {:ok, _node} = Cluster.spawn_node(@node3)
 
-    # add third node to cluster, meeting min quorum requirements
-    {:ok, _node} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+      # register name task should now complete
+      {:ok, pid} = Task.await(registration, 5_000)
 
-    # register name should now succeed
-    Task.await(registration, 5_000)
+      # ensure all nodes have name registered to started process
+      Enum.each([@node1, @node2, @node3], fn node ->
+        assert whereis_name(node, {:test, 1}) == pid
+        assert get_registry(node) == [{{:test, 1}, pid}]
+      end)
 
-    assert_receive(:tracked)
+      assert :ok = unregister_name(@node1, {:test, 1})
+    end
   end
 
   describe "with quorum cluster" do
-    setup [:start_third_node]
+    setup [:form_three_node_cluster]
 
-    test "kill process after topology change results in no available node to host", %{node3: node3} do
-      {:ok, pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
-
-      ref = Process.monitor(pid)
-
-      # stopping node3 means not enough needs for a quorum, running processes must be stopped
-      Swarm.Cluster.stop_node(node3)
-
-      assert_receive {:DOWN, ^ref, _, _, _}
+    test "should immediately start registered process" do
+      assert {:ok, pid} = register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
+      assert :ok = unregister_name(@node1, {:test, 1})
     end
 
-    test "restart a killed process after topology change restores min quorum", %{node3: node3} do
-      {:ok, pid} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+    test "should kill process after topology change results in too few nodes to host" do
+      {:ok, pid} = register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
 
       ref = Process.monitor(pid)
 
-      # stopping node3 means not enough needs for a quorum, running processes must be stopped
-      Swarm.Cluster.stop_node(node3)
+      # stopping a node means not enough nodes for a quorum, running processes must be stopped
+      Cluster.stop_node(@node3)
+
+      assert_receive {:DOWN, ^ref, _, _, _}
+
+      Enum.each([@node1, @node2], fn node ->
+        assert whereis_name(node, {:test, 1}) == :undefined
+        assert get_registry(node) == []
+      end)
+    end
+
+    test "should restart a killed process after topology change restores min quorum" do
+      {:ok, pid} = register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
+
+      ref = Process.monitor(pid)
+
+      # stopping a node means not enough needs for a quorum, running processes must be stopped
+      Cluster.stop_node(@node1)
       assert_receive {:DOWN, ^ref, _, _, _}
 
       # restore third node to cluster, meeting min quorum requirements
-      {:ok, _node3} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+      {:ok, _node} = Cluster.spawn_node(@node1)
 
-      assert Swarm.whereis_name({:test, 1}) != :undefined
-    end
+      # wait for node to start
+      :timer.sleep 1_000
 
-    # add third node to cluster, meeting min quorum requirements
-    defp start_third_node(_context) do
-      {:ok, node3} = Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+      # ensure all nodes have name registered to started process
+      Enum.each([@node1, @node2, @node3], fn node ->
+        pid = whereis_name(node, {:test, 1})
 
-      [node3: node3]
+        refute pid == :undefined
+        assert get_registry(node) == [{{:test, 1}, pid}]
+      end)
+
+      assert :ok = unregister_name(@node1, {:test, 1})
     end
   end
 
-  defp restart_cluster_using_strategy(strategy) do
-    Swarm.Cluster.stop()
+  describe "net split" do
+    setup [:form_five_node_cluster]
+
+    test "should redistribute processes from smaller to larger partition" do
+      names = [{:test, 1}, {:test, 2}, {:test, 3}, {:test, 4}, {:test, 5}]
+
+      # start worker for each name
+      Enum.each(names, fn name ->
+        with {:ok, pid} <- register_name(@node1, name, MyApp.WorkerSup, :register, []) do
+          pid
+        end
+      end)
+
+      :timer.sleep 1_000
+
+      # simulate net split (1, 2, 3) and (4, 5)
+      Node.disconnect(@node4)
+      Node.disconnect(@node5)
+
+      :timer.sleep 1_000
+
+      # ensure processes are redistributed onto nodes 1, 2, or 3 (quorum)
+      names
+      |> Enum.map(&whereis_name(@node1, &1))
+      |> Enum.each(fn pid ->
+        refute pid == :undefined
+
+        case node(pid) do
+          @node4 -> flunk "process still running on node4"
+          @node5 -> flunk "process still running on node5"
+          _ -> :ok
+        end
+      end)
+
+      Enum.each(names, fn name ->
+        assert :ok = unregister_name(@node1, name)
+      end)
+    end
+  end
+
+  defp get_registry(node) do
+    :rpc.call(node, Swarm, :registered, [], :infinity)
+  end
+
+  defp register_name(node, name, m, f, a) do
+    :rpc.call(node, Swarm, :register_name, [name, m, f, a], :infinity)
+  end
+
+  defp unregister_name(node, name) do
+    :rpc.call(node, Swarm, :unregister_name, [name], :infinity)
+  end
+
+  defp whereis_name(node, name) do
+    :rpc.call(node, Swarm, :whereis_name, [name], :infinity)
+  end
+
+  defp form_two_node_cluster(_context) do
+    with {:ok, _node1} <- Cluster.spawn_node(@node1),
+         {:ok, _node2} <- Cluster.spawn_node(@node2) do
+      :ok
+    end
+  end
+
+  defp form_three_node_cluster(_context) do
+    with {:ok, _node1} <- Cluster.spawn_node(@node1),
+         {:ok, _node2} <- Cluster.spawn_node(@node2),
+         {:ok, _node3} <- Cluster.spawn_node(@node3) do
+      :ok
+    end
+  end
+
+  defp form_five_node_cluster(_context) do
+    with {:ok, _node1} <- Cluster.spawn_node(@node1),
+         {:ok, _node2} <- Cluster.spawn_node(@node2),
+         {:ok, _node3} <- Cluster.spawn_node(@node3),
+         {:ok, _node4} <- Cluster.spawn_node(@node4),
+         {:ok, _node5} <- Cluster.spawn_node(@node5) do
+      :ok
+    end
+  end
+
+  defp restart_cluster_using_strategy(strategy, nodes) do
+    Cluster.stop()
 
     Application.put_env(:swarm, :distribution_strategy, strategy)
-
     Application.stop(:swarm)
 
-    Swarm.Cluster.spawn()
+    Cluster.spawn(nodes)
 
     Application.ensure_all_started(:swarm)
   end

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -8,7 +8,7 @@ defmodule Swarm.QuorumTests do
   setup_all do
     :rand.seed(:exs64)
 
-    Application.put_env(:swarm, :min_quorum_node_size, 3)
+    Application.put_env(:swarm, :static_quorum_size, 3)
     restart_cluster_using_strategy(StaticQuorumRing)
 
     {:ok, _} = MyApp.WorkerSup.start_link()

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -1,0 +1,66 @@
+defmodule Swarm.QuorumTests do
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Swarm.Distribution.StaticQuorumRing
+
+  setup_all do
+    :rand.seed(:exs64)
+
+    Application.put_env(:swarm, :min_quorum_node_size, 3)
+    restart_cluster_using_strategy(StaticQuorumRing)
+
+    {:ok, _} = MyApp.WorkerSup.start_link()
+
+    on_exit fn ->
+      restart_cluster_using_strategy(RingStrategy)
+    end
+
+    :ok
+  end
+
+  test "block until quorum size reached" do
+    quorum =
+      StaticQuorumRing.create()
+      |> StaticQuorumRing.add_node("node1")
+      |> StaticQuorumRing.add_node("node2")
+
+    assert StaticQuorumRing.key_to_node(quorum, :key1) == :undefined
+
+    quorum = StaticQuorumRing.add_node(quorum, "node3")
+
+    assert StaticQuorumRing.key_to_node(quorum, :key1) != :undefined
+  end
+
+  @tag :wip
+  test "block track until quorum size reached" do
+    reply_to = self()
+
+    registration = Task.async(fn ->
+      {:ok, pid1} = Swarm.register_name({:test, 1}, MyApp.WorkerSup, :register, [])
+
+      send(reply_to, :tracked)
+    end)
+
+    refute_receive(:tracked)
+
+    # add third node to cluster, meeting min quorum requirements
+    Swarm.Cluster.spawn_node(:"node3@127.0.0.1")
+
+    # register name should now succeed
+    Task.await(registration, 5_000)
+
+    assert_receive(:tracked)
+  end
+
+  defp restart_cluster_using_strategy(strategy) do
+    Swarm.Cluster.stop()
+
+    Application.put_env(:swarm, :distribution_strategy, strategy)
+
+    Swarm.Cluster.spawn()
+
+    Application.ensure_all_started(:swarm)
+  end
+end

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -36,7 +36,7 @@ defmodule Swarm.RegistryTests do
     assert entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _) = Swarm.Registry.get_by_ref(ref1)
     assert entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _) = Swarm.Registry.get_by_ref(ref2)
 
-    assert [entry(pid: ^pid1), entry(pid: ^pid2)] = Swarm.Registry.get_by_meta(:mfa, {MyApp.WorkerSup, :register, []})
+    assert [entry(pid: ^pid2), entry(pid: ^pid1)] = Swarm.Registry.get_by_meta(:mfa, {MyApp.WorkerSup, :register, []})
 
     assert [entry(pid: ^pid1)] = :ets.lookup(:swarm_registry, {:test, 1})
   end
@@ -44,6 +44,7 @@ defmodule Swarm.RegistryTests do
   test "join/2 (joining a group does not create race conditions)" do
     # https://github.com/bitwalker/swarm/issues/14
     {:ok, pid} = Agent.start_link(fn -> "testing" end)
+    Swarm.register_name(:agent, pid)
     Swarm.join(:agents, pid)
     assert [my_agent] = Swarm.members(:agents)
     assert "testing" == Agent.get(my_agent, fn s -> s end)

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -17,6 +17,7 @@ defmodule Swarm.Cluster do
   end
 
   def stop do
+    Application.stop(:swarm)
     :ok = Application.unload(:swarm)
 
     nodes = Node.list(:connected)

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -56,6 +56,7 @@ defmodule Swarm.Cluster do
     for {app_name, _, _} <- Application.loaded_applications do
       rpc(node, Application, :ensure_all_started, [app_name])
     end
+    rpc(node, MyApp.WorkerSup, :start_link, [])
   end
 
   defp node_name(node_host) do

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,13 +1,11 @@
 defmodule Swarm.Cluster do
-  def spawn do
+  def spawn(nodes \\ Application.get_env(:swarm, :nodes, [])) do
     # Turn node into a distributed node with the given long name
     :net_kernel.start([:"primary@127.0.0.1"])
 
     # Allow spawned nodes to fetch all code from this node
     :erl_boot_server.start([])
     allow_boot to_charlist("127.0.0.1")
-
-    nodes = Application.get_env(:swarm, :nodes, [])
 
     case Application.load(:swarm) do
       :ok -> :ok

--- a/test/tracker_test.exs
+++ b/test/tracker_test.exs
@@ -38,5 +38,4 @@ defmodule Swarm.TrackerTests do
 
     assert [entry(pid: ^pid)] = :ets.lookup(:swarm_registry, :test1)
   end
-
 end


### PR DESCRIPTION
Adds new strategy module `Swarm.Distribution.StaticQuorumRing`. This is used to provide consistency during a network partition.

The strategy is configured with a quorum size which defines the minimum number of nodes that must be connected in the cluster to allow process registration and distribution. If there are fewer nodes available than the quorum size, any calls to `Swarm.register_name/5` will block until enough nodes have started.

The `Swarm.Distribution.Strategy.key_to_node/2` function may return `:undefined` to indicate that there is no available node to start the process. In this case the tracker will record the registration as pending. It will attempt to start the process whenever the network topology changes. Should a node go down, or during a net split, any process that are currently running but are determined to have no node available will be stopped. They will be restarted whenever a node becomes available, as determined by the same consistent named based hash ring distribution using libring. Additional ring distribution strategies can now be written that take advantage of consistency, instead of availability, by returning `:undefined` node.

A full suite of tests for the new functionality are included in `test/quorum_test.exs`.

Please let me know of any issues or changes you recommend.