### PR TITLE
Name registration error returned if no available node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 - Default `node_blacklist` was expanded to ignore hot upgrade scripting
   nodes as setup by exrm/relx/distillery.
+- New distribution strategy module `Swarm.Distribution.StaticQuorumRing` used to
+  provide consistency during a network partition ([#38](https://github.com/bitwalker/swarm/pull/38)).
 
 ## Fixed
 
 - When registering a name via `register_name/4` which is already registered,
   ensure the process we created via `apply/3` is killed.
-  
+- Add local registration when restarted named process is already started but unknown locally ([#46](https://github.com/bitwalker/swarm/pull/46)).
+
 ## 2.0
 
 ## Removed

--- a/README.md
+++ b/README.md
@@ -92,12 +92,10 @@ Swarm provides two strategies for you to use:
   system.
 
   You configure the quorum size by defining the minimum number of nodes that must be connected in the
-  cluster to allow process registration and distribution. If there are fewer nodes currently
-  available than the quorum size, any calls to `Swarm.register_name/5` will block until enough nodes
-  have started.
+  cluster to allow process registration and distribution. Calls to `Swarm.register_name/5` will return `{:error, :no_node_available}` if there are fewer nodes available than the configured minimum quorum size.
 
   In a network partition, the partition containing at least the quorum size number of clusters will
-  continue operation. Processes running on the other side of the split will be stopped, and restarted
+  continue operation. Processes running on the other side of the split will be stopped and restarted
   on the active side. This ensures that only one instance of a registered process will be running in
   the cluster.
 

--- a/lib/swarm.ex
+++ b/lib/swarm.ex
@@ -37,7 +37,13 @@ defmodule Swarm do
   or an error tuple if registration fails. You cannot use this with processes which
   are already started, it must be started by `:swarm`.
 
-  You can optionally provide a `:timeout` value to limit the duration of blocking calls.
+  A call to `Swarm.register_name/5` will return `{:error, :no_node_available}`
+  when the configured distribution strategy returns `:undefined` as the node to
+  host the named process. This indicates that there are too few nodes available to
+  start a process. You can retry the name registration while waiting for nodes
+  to join the cluster.
+
+  Provide an optional `:timeout` value to limit the duration of register name calls.
   The default value is `:infinity` to block indefinitely.
   """
   @spec register_name(term, atom(), atom(), [term]) :: {:ok, pid} | {:error, term}

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -1,44 +1,51 @@
 defmodule Swarm.Distribution.StaticQuorumRing do
   @moduledoc """
-  A quorum is the minimum number of nodes that a distributed cluster has to obtain in order to be
-  allowed to perform an operation. This can be used to enforce consistent operation in a distributed system.
+  A quorum is the minimum number of nodes that a distributed cluster has to
+  obtain in order to be allowed to perform an operation. This can be used to
+  enforce consistent operation in a distributed system.
 
   ## Quorum size
 
-  You must configure the distribution strategy and its quorum size using the `:static_quorum_size` setting:
+  You must configure this distribution strategy and specify its minimum quorum
+  size:
 
       config :swarm,
         distribution_strategy: Swarm.Distribution.StaticQuorumRing,
         static_quorum_size: 5
 
-  It defines the minimum number of nodes that must be connected in the cluster to allow process
-  registration and distribution.
+  It defines the minimum number of nodes that must be connected in the cluster
+  to allow process registration and distribution.
 
-  If there are fewer nodes currently available than the quorum size, any calls to
-  `Swarm.register_name/5` will block until enough nodes have started.
+  If there are fewer nodes currently available than the quorum size, any calls
+  to `Swarm.register_name/5` will return `{:error, :no_node_available}` until
+  enough nodes have started.
 
-  You can configure the `:kernel` application to wait for cluster formation before starting your
-  application during node start up. The `sync_nodes_optional` configuration specifies which nodes
-  to attempt to connect to within the `sync_nodes_timeout` window, defined in milliseconds, before
-  continuing with startup. There is also a `sync_nodes_mandatory` setting which can be used to
-  enforce all nodes are connected within the timeout window or else the node terminates.
+  You can configure the `:kernel` application to wait for cluster formation
+  before starting your application during node start up. The
+  `sync_nodes_optional` configuration specifies which nodes to attempt to
+  connect to within the `sync_nodes_timeout` window, defined in milliseconds,
+  before continuing with startup. There is also a `sync_nodes_mandatory` setting
+  which can be used to enforce all nodes are connected within the timeout window
+  or else the node terminates.
 
       config :kernel,
         sync_nodes_optional: [:"node1@192.168.1.1", :"node2@192.168.1.2"],
         sync_nodes_timeout: 60_000
 
-  The `sync_nodes_timeout` can be configured as `:infinity` to wait indefinitely for all nodes to
-  connect. All involved nodes must have the same value for `sync_nodes_timeout`.
+  The `sync_nodes_timeout` can be configured as `:infinity` to wait indefinitely
+  for all nodes to connect. All involved nodes must have the same value for
+  `sync_nodes_timeout`.
 
   ### Example
 
-  In a 9 node cluster you would configure the `:static_quorum_size` as 5. If there is a network split
-  of 4 and 5 nodes, processes on the side with 5 nodes will continue running but processes on the
-  other 4 nodes will be stopped.
+  In a 9 node cluster you would configure the `:static_quorum_size` as 5. During
+  a network split of 4 and 5 nodes, processes on the side with 5 nodes
+  will continue running, whereas processes on the other 4 nodes will be stopped.
 
-  Be aware that in the running 5 node cluster, no more failures can be handled because the
-  remaining cluster size would be less than 5. In the case of another failure in that 5 node
-  cluster all running processes will be stopped.
+  Be aware that in the running 5 node cluster, no more failures can be handled
+  because the remaining cluster size would be less than the required 5 node
+  minimum. All running processes would be stopped in the case of another single
+  node failure.
   """
 
   use Swarm.Distribution.Strategy

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1080,12 +1080,13 @@ defmodule Swarm.Tracker do
   end
 
   # Attempt to start a named process on its destination node
-  defp do_track(%{name: name, m: m, f: f, a: a, from: from} = tracking, %{strategy: strategy} = state) do
+  defp do_track(%Tracking{name: name, m: m, f: f, a: a, from: from}, %TrackerState{strategy: strategy} = state) do
     current_node = Node.self()
     case Strategy.key_to_node(strategy, name) do
       :undefined ->
         warn "no node available to start #{inspect name} process"
         GenStateMachine.reply(from, {:error, :no_node_available})
+        :keep_state_and_data
       ^current_node ->
         case Registry.get_by_name(name) do
           :undefined ->

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -73,7 +73,7 @@ defmodule Swarm.Tracker do
   If the process's parent node goes down, it will be restarted on the new node which own's it's keyspace.
   If the cluster topology changes, and the owner of it's keyspace changes, it will be shifted to
   the new owner, after initiating the handoff process as described in the documentation.
-  If there is no node available to start the process, the track call will return an error tagged tuple `{error, :no_node_available}`.
+  A track call will return an error tagged tuple, `{:error, :no_node_available}`, if there is no node available to start the process.
   Provide a timeout value to limit the track call duration. A value of `:infinity` can be used to block indefinitely.
   """
   def track(name, m, f, a, timeout) when is_atom(m) and is_atom(f) and is_list(a),

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -23,6 +23,8 @@ defmodule Swarm.QuorumTests do
     {:ok, _} = MyApp.WorkerSup.start_link()
 
     on_exit fn ->
+      Application.delete_env(:swarm, :static_quorum_size)
+
       nodes = Application.get_env(:swarm, :nodes, [])
       restart_cluster_using_strategy(Ring, nodes)
     end

--- a/test/quorum_test.exs
+++ b/test/quorum_test.exs
@@ -42,30 +42,16 @@ defmodule Swarm.QuorumTests do
   describe "without quorum cluster" do
     setup [:form_two_node_cluster]
 
-    test "block name registration until quorum size reached" do
-      registration = Task.async(fn ->
-        register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
+    test "should error on name registration" do
+      assert {:error, :no_node_available} = register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
+
+      Enum.each([@node1, @node2], fn node ->
+        assert whereis_name(node, {:test, 1}) == :undefined
+        assert get_registry(node) == []
       end)
-
-      # ensure registration is blocked, and process has not yet started/registered
-      assert get_registry(@node1) == []
-
-      # add third node to cluster, meeting min quorum requirements
-      {:ok, _node} = Cluster.spawn_node(@node3)
-
-      # register name task should now complete
-      {:ok, pid} = Task.await(registration, 5_000)
-
-      # ensure all nodes have name registered to started process
-      Enum.each([@node1, @node2, @node3], fn node ->
-        assert whereis_name(node, {:test, 1}) == pid
-        assert get_registry(node) == [{{:test, 1}, pid}]
-      end)
-
-      assert :ok = unregister_name(@node1, {:test, 1})
     end
 
-    test "should timeout a blocking track call, if provided" do
+    test "should optionally timeout a track call" do
       case register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [], 0) do
         {:error, {:EXIT, {:timeout, _}}} -> :ok
         reply -> flunk("expected timeout, instead received: #{inspect reply}")
@@ -121,48 +107,12 @@ defmodule Swarm.QuorumTests do
       end)
     end
 
-    test "should restart all killed processes after topology change restores min quorum" do
-      refs = start_named_processes()
-
-      :timer.sleep 1_000
-
-      # stopping one node means not enough needs for a quorum, running processes must be stopped
-      Cluster.stop_node(@node1)
-
-      # ensure all processes have been stopped
-      Enum.each(refs, fn ref ->
-        assert_receive {:DOWN, ^ref, _, _, _}
-      end)
-
-      # restore third node to cluster, meeting min quorum requirements
-      {:ok, _node} = Cluster.spawn_node(@node1)
-
-      # wait for node to start
-      :timer.sleep 1_000
-
-      # ensure all nodes have names registered to started processes
-      Enum.each([@node1, @node2, @node3], fn node ->
-        pids = Enum.map(@names, &whereis_name(node, &1))
-        registry = get_registry(node) |> Enum.sort_by(fn {{:test, n}, _} -> n end)
-
-        refute Enum.member?(pids, :undefined)
-        assert registry == Enum.zip(@names, pids)
-      end)
-
-      # ensure processes are alive
-      Enum.each(@names, fn name ->
-        pid = whereis_name(@node1, name)
-        node = node(pid)
-
-        assert :rpc.call(node, Process, :alive?, [pid], :infinity)
-        assert :ok = unregister_name(node, name)
-      end)
-    end
-
     test "should unregister name" do
       {:ok, _pid} = register_name(@node1, {:test, 1}, MyApp.WorkerSup, :register, [])
 
       assert :ok = unregister_name(@node1, {:test, 1})
+
+      :timer.sleep 1_000
 
       Enum.each([@node1, @node2, @node3], fn node ->
        assert whereis_name(node, {:test, 1}) == :undefined


### PR DESCRIPTION
A call to `Swarm.register_name/5` will return `{:error, :no_node_available}` when the configured distribution strategy returns `:undefined` as the node to host the named process. This indicates that there are too few nodes available to start a process. 

This pull request simplifies the tracker process by removing the pending name registrations when the distribution strategy indicates there is no available node to host the process. This is only applicable when using the `Swarm.Distribution.StaticQuorumRing` strategy module.

Previously the register name call would block indefinitely until the process could be started (once a node became available). The amended behaviour is to return an error tagged tuple to indicate that registration has failed.  The caller should handle retrying while waiting for the cluster to form. It also allows errors to be logged and monitored. 