### PR TITLE
Add local registration when restarted named process is already started but unknown locally

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -139,7 +139,7 @@ defmodule Swarm.Tracker do
     # wait for node list to populate
     nodelist = Enum.reject(Node.list(:connected), &ignore_node?/1)
 
-    strategy = 
+    strategy =
       Node.self
       |> Strategy.create()
       |> Strategy.add_nodes(nodelist)
@@ -556,17 +556,17 @@ defmodule Swarm.Tracker do
   end
   def tracking(:info, {:nodeup, node, _}, state) do
     state
-    |> nodeup(node) 
+    |> nodeup(node)
     |> handle_node_status()
   end
   def tracking(:info, {:nodedown, node, _}, state) do
     state
-    |> nodedown(node) 
+    |> nodedown(node)
     |> handle_node_status()
   end
   def tracking(:info, {:ensure_swarm_started_on_remote_node, node, attempts}, state) do
     state
-    |> ensure_swarm_started_on_remote_node(node, attempts) 
+    |> ensure_swarm_started_on_remote_node(node, attempts)
     |> handle_node_status()
   end
   def tracking(:info, :anti_entropy, state) do
@@ -1178,11 +1178,10 @@ defmodule Swarm.Tracker do
             _   -> GenStateMachine.reply(from, {:ok, pid})
           end
         {:error, {:already_registered, pid}} ->
-          debug "#{inspect name} already registered to #{inspect pid} on #{node(pid)}"
-          case from do
-            nil -> :ok
-            _   -> GenStateMachine.reply(from, {:ok, pid})
-          end
+          debug "#{inspect name} already registered to #{inspect pid} on #{node(pid)}, registering locally"
+          # register named process that is unknown locally
+          add_registration({name, pid, %{mfa: {m,f,a}}}, from, state)
+          :ok
         {:error, {:noproc, _}} = err ->
           warn "#{inspect name} could not be started on #{remote_node}: #{inspect err}, retrying operation after #{@retry_interval}ms.."
           :timer.sleep @retry_interval
@@ -1380,7 +1379,7 @@ defmodule Swarm.Tracker do
   defp nodeup(%TrackerState{nodes: nodes, strategy: strategy} = state, node) do
     cond do
       node == Node.self ->
-        new_strategy = 
+        new_strategy =
           strategy
           |> Strategy.remove_node(state.self)
           |> Strategy.add_node(node)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -4,7 +4,16 @@ defmodule Swarm.IntegrationTest do
   @primary :"primary@127.0.0.1"
   @node1 :"node1@127.0.0.1"
   @node2 :"node2@127.0.0.1"
+  @nodes [@node1, @node2]
   @worker_count 10
+
+  setup do
+    on_exit fn ->
+      for {_name, pid} <- get_registry(@node1), do: shutdown(pid)
+    end
+
+    :ok
+  end
 
   test "correct redistribution of processes" do
     for n <- 1..@worker_count do
@@ -42,6 +51,46 @@ defmodule Swarm.IntegrationTest do
     assert length(workers_for(@node2)) < @worker_count
   end
 
+  test "redistribute already started process" do
+    {_, {:ok, pid1}} = spawn_restart_worker(@node1, {:worker, 1})
+    {_, {:ok, pid2}} = spawn_restart_worker(@node1, {:worker, 2})
+
+    Enum.each(@nodes, fn node ->
+      assert get_registry(node) == [{{:worker, 1}, pid1}, {{:worker, 2}, pid2}]
+    end)
+
+    # netsplit
+    simulate_disconnect(@node1, @node2)
+
+    # wait for process redistribution
+    Process.sleep(1_000)
+
+    # both worker processes should be running on each node
+    assert whereis_name(@node1, {:worker, 1}) != whereis_name(@node2, {:worker, 1})
+    assert whereis_name(@node1, {:worker, 2}) != whereis_name(@node2, {:worker, 2})
+
+    Enum.each(@nodes, fn node ->
+      # both nodes should be aware of two workers
+      assert get_registry(node) |> length() == 2
+    end)
+
+    # restore the cluster
+    simulate_reconnect(@node1, @node2)
+
+    # give time to sync
+    Process.sleep(1_000)
+
+    pid1 = whereis_name(@node1, {:worker, 1})
+    pid2 = whereis_name(@node1, {:worker, 2})
+
+    Enum.each(@nodes, fn node ->
+      assert get_registry(node) == [{{:worker, 1}, pid1}, {{:worker, 2}, pid2}]
+    end)
+
+    shutdown(pid1)
+    shutdown(pid2)
+  end
+
   defp disconnect(node, opts) do
     from = Keyword.fetch!(opts, :from)
     :rpc.call(node, Node, :disconnect, [from])
@@ -56,9 +105,35 @@ defmodule Swarm.IntegrationTest do
     :rpc.call(node, Swarm, :registered, [], :infinity)
   end
 
+  defp whereis_name(node, name) do
+    :rpc.call(node, Swarm, :whereis_name, [name], :infinity)
+  end
+
+  # simulate a disconnect between two nodes
+  defp simulate_disconnect(lnode, rnode) do
+    send({Swarm.Tracker, lnode}, {:nodedown, rnode, nil})
+    send({Swarm.Tracker, rnode}, {:nodedown, lnode, nil})
+  end
+
+  # simulate a reconnect between two nodes
+  defp simulate_reconnect(lnode, rnode) do
+    spawn(fn -> send({Swarm.Tracker, lnode}, {:nodeup, rnode, nil}) end)
+    spawn(fn -> send({Swarm.Tracker, rnode}, {:nodeup, lnode, nil}) end)
+  end
+
   defp workers_for(node) do
     node
     |> get_registry()
     |> Enum.filter(fn {_, pid} -> node(pid) == node end)
+  end
+
+  def shutdown(nil), do: :ok
+  def shutdown(pid) when is_pid(pid) do
+    ref = Process.monitor(pid)
+
+    Process.unlink(pid)
+    Process.exit(pid, :shutdown)
+
+    assert_receive {:DOWN, ^ref, _, _, _}
   end
 end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -28,6 +28,12 @@ defmodule Swarm.NodeCase do
     end)
   end
 
+  def spawn_restart_worker(node, name) do
+    call_node(node, fn ->
+      Swarm.register_name(name, MyApp.RestartWorker, :start_link, [name])
+    end)
+  end
+
   def flush() do
     receive do
       _ -> flush()

--- a/test/support/restart_worker.ex
+++ b/test/support/restart_worker.ex
@@ -1,0 +1,17 @@
+defmodule MyApp.RestartWorker do
+  @moduledoc false
+
+  # A worker process that requests to be restarted during Swarm hand-off
+
+  def start_link(name), do: GenServer.start_link(__MODULE__, name)
+
+  def init(name), do: {:ok, name}
+
+  def handle_call({:swarm, :begin_handoff}, _from, state) do
+    {:reply, :restart, state}
+  end
+
+  def handle_info({:swarm, :die}, state) do
+    {:stop, :shutdown, state}
+  end
+end


### PR DESCRIPTION
When a node comes up and a process requires redistribution, but is already running on the target node, we add the PID to the local registry.

Fixes #45.