### PR TITLE
Retry start_pid_remotely when module not (yet) available on target node

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1137,6 +1137,10 @@ defmodule Swarm.Tracker do
           warn "#{inspect name} could not be started on #{remote_node}: #{inspect err}, retrying operation after #{@retry_interval}ms.."
           :timer.sleep @retry_interval
           start_pid_remotely(remote_node, from, name, meta, state, attempts + 1)
+        {:error, :undef} = err ->
+          warn "#{inspect name} could not be started on #{remote_node}: target module not available on remote node, retrying operation after #{@retry_interval}ms.."
+          :timer.sleep @retry_interval
+          start_pid_remotely(remote_node, from, name, meta, state, attempts + 1)
         {:error, _reason} = err ->
           warn "#{inspect name} could not be started on #{remote_node}: #{inspect err}"
           reply(from, err)


### PR DESCRIPTION
Patch to address Issue #55.

Occurs when Swarm is up and running on a newly-started node and accepts a start process request from another Swarm instance before the code to be started has been loaded on the new node.