### PR TITLE
No hand-off or restart for processes started with `Swarm.register_name/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ N/A
 
 ### Fixed
 
-N/A
+Don't attempt to hand-off or restart processes started with `Swarm.register_name/2` ([#63](https://github.com/bitwalker/swarm/pull/63)). Fixes #62.
 
 ## 3.1
 
 ### Changed
 
 - Default `node_blacklist` was expanded to ignore hot upgrade scripting nodes as setup by exrm/relx/distillery.
-  
+
 ### Added
 
 - New distribution strategy module `Swarm.Distribution.StaticQuorumRing` used to provide consistency during a network partition ([#38](https://github.com/bitwalker/swarm/pull/38)).

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -692,7 +692,7 @@ defmodule Swarm.Tracker do
     debug "topology change (#{type} for #{remote_node})"
     current_node = state.self
     new_clock = Registry.reduce(state.clock, fn
-      entry(name: name, pid: pid, meta: meta) = obj, lclock when node(pid) == current_node ->
+      entry(name: name, pid: pid, meta: %{mfa: _mfa} = meta) = obj, lclock when node(pid) == current_node ->
         case Strategy.key_to_node(state.strategy, name) do
           :undefined ->
             # No node available to host process, it must be stopped
@@ -734,7 +734,7 @@ defmodule Swarm.Tracker do
                 lclock
             end
         end
-      entry(name: name, pid: pid, meta: meta) = obj, lclock when is_map(meta) ->
+      entry(name: name, pid: pid, meta: %{mfa: _mfa} = meta) = obj, lclock when is_map(meta) ->
         cond do
           Enum.member?(state.nodes, node(pid)) ->
             # the parent node is still up

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -38,6 +38,14 @@ defmodule Swarm.NodeCase do
     end)
   end
 
+  def spawn_agent(node, name, initial_state) do
+    call_node(node, fn ->
+      {:ok, pid} = Agent.start(fn -> initial_state end)
+
+      Swarm.register_name(name, pid)
+    end)
+  end
+
   def flush() do
     receive do
       _ -> flush()


### PR DESCRIPTION
Fixes #62.