### PR TITLE
fix issue with StaticQuorumRing size

### DIFF
--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -55,13 +55,8 @@ defmodule Swarm.Distribution.StaticQuorumRing do
   defstruct [:static_quorum_size, :ring]
 
   def create do
-    static_quorum_size =
-      Application.get_env(:swarm, :static_quorum_size, 2)
-      |> Integer.parse()
-      |> elem(0)
-    
     %StaticQuorumRing{
-      static_quorum_size: static_quorum_size,
+      static_quorum_size: static_quorum_size(),
       ring: HashRing.new(),
     }
   end
@@ -100,5 +95,18 @@ defmodule Swarm.Distribution.StaticQuorumRing do
       node_count when node_count < static_quorum_size -> :undefined
       _ -> HashRing.key_to_node(ring, key)
     end
+  end
+
+  defp static_quorum_size() do
+    Application.get_env(:swarm, :static_quorum_size, 2)
+    |> static_quorum_size()
+  end
+
+  defp static_quorum_size(nil), do: 2
+  defp static_quorum_size(size) when is_integer(size), do: size
+  defp static_quorum_size(binary) when is_binary(binary) do
+    binary
+    |> Integer.parse()
+    |> elem(0)
   end
 end

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -102,11 +102,16 @@ defmodule Swarm.Distribution.StaticQuorumRing do
     |> static_quorum_size()
   end
 
-  defp static_quorum_size(nil), do: 2
-  defp static_quorum_size(size) when is_integer(size), do: size
+  defp static_quorum_size(nil), do: static_quorum_size(2)
   defp static_quorum_size(binary) when is_binary(binary) do
     binary
     |> Integer.parse()
-    |> elem(0)
+    |> convert_to_integer()
+    |> static_quorum_size()
   end
+  defp static_quorum_size(size) when is_integer(size) and size > 0, do: size
+  defp static_quorum_size(_size), do: raise "config :static_quorum_size should be a positive integer"
+
+  defp convert_to_integer({integer, _}) when is_integer(integer), do: integer
+  defp convert_to_integer(other), do: other
 end

--- a/lib/swarm/distribution/static_quorum_ring.ex
+++ b/lib/swarm/distribution/static_quorum_ring.ex
@@ -55,8 +55,13 @@ defmodule Swarm.Distribution.StaticQuorumRing do
   defstruct [:static_quorum_size, :ring]
 
   def create do
+    static_quorum_size =
+      Application.get_env(:swarm, :static_quorum_size, 2)
+      |> Integer.parse()
+      |> elem(0)
+    
     %StaticQuorumRing{
-      static_quorum_size: Application.get_env(:swarm, :static_quorum_size, 2),
+      static_quorum_size: static_quorum_size,
       ring: HashRing.new(),
     }
   end

--- a/test/distribution/static_quorum_ring_test.exs
+++ b/test/distribution/static_quorum_ring_test.exs
@@ -18,4 +18,13 @@ defmodule Swarm.Distribution.StaticQuorumRingTests do
     quorum = StaticQuorumRing.add_node(quorum, "node3")
     assert StaticQuorumRing.key_to_node(quorum, :key1) != :undefined
   end
+
+  test "quorum size should be set by binary setting" do
+    static_quorum_size = Application.get_env(:swarm, :static_quorum_size)
+    Application.put_env(:swarm, :static_quorum_size, "5")
+
+    assert StaticQuorumRing.create() == %StaticQuorumRing{ring: %HashRing{}, static_quorum_size: 5}
+
+    Application.put_env(:swarm, :static_quorum_size, static_quorum_size)
+  end
 end

--- a/test/distribution/static_quorum_ring_test.exs
+++ b/test/distribution/static_quorum_ring_test.exs
@@ -27,4 +27,22 @@ defmodule Swarm.Distribution.StaticQuorumRingTests do
 
     Application.put_env(:swarm, :static_quorum_size, static_quorum_size)
   end
+
+  test "creating StaticQuorumRing should raise if the setting is not a positive integer" do
+    static_quorum_size = Application.get_env(:swarm, :static_quorum_size)
+
+    Application.put_env(:swarm, :static_quorum_size, 0)
+    assert_raise(RuntimeError, "config :static_quorum_size should be a positive integer", &StaticQuorumRing.create/0)
+
+    Application.put_env(:swarm, :static_quorum_size, {:strange, :tuple})
+    assert_raise(RuntimeError, "config :static_quorum_size should be a positive integer", &StaticQuorumRing.create/0)
+
+    Application.put_env(:swarm, :static_quorum_size, 0.5)
+    assert_raise(RuntimeError, "config :static_quorum_size should be a positive integer", &StaticQuorumRing.create/0)
+
+    Application.put_env(:swarm, :static_quorum_size, "fake")
+    assert_raise(RuntimeError, "config :static_quorum_size should be a positive integer", &StaticQuorumRing.create/0)
+
+    Application.put_env(:swarm, :static_quorum_size, static_quorum_size)
+  end
 end


### PR DESCRIPTION
When loading envs from erlang variables in releases the variables are loaded as strings as far as I know.

Then this happens:
    "5" < 2

Which results in always giving `:undefined` as a proposed node by `StaticQuorumRing`