### PR TITLE
Ignore order of registry entries

### DIFF
--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -46,13 +46,23 @@ defmodule Swarm.RegistryTests do
     assert entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _) = Swarm.Registry.get_by_ref(ref1)
     assert entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _) = Swarm.Registry.get_by_ref(ref2)
 
-    assert [
-             entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _),
-             entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _)
-           ] = Swarm.Registry.get_by_meta(:mfa, {MyApp.WorkerSup, :register, []})
+    meta_enum = Swarm.Registry.get_by_meta(:mfa, {MyApp.WorkerSup, :register, []})
+
+    assert Enum.find(
+             meta_enum,
+             &match?(entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _), &1)
+           ) != nil
+
+    assert Enum.find(
+             meta_enum,
+             &match?(entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _), &1)
+           ) != nil
 
     assert [entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _)] =
              :ets.lookup(:swarm_registry, {:test, 1})
+
+    assert [entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _)] =
+             :ets.lookup(:swarm_registry, {:test, 2})
   end
 
   test "join/2 (joining a group does not create race conditions)" do


### PR DESCRIPTION
When running the tests, sometimes there is an error due to the assert taking list ordering into account:

```
1) test register_name/4 (Swarm.RegistryTests)
     test/registry_test.exs:15
     match (=) failed
     The following variables were pinned:
       pid2 = #PID<0.360.0>
       pid1 = #PID<0.359.0>
     code:  assert [entry(name: _, pid: ^pid2, ref: _, meta: _, clock: _), entry(name: _, pid: ^pid1, ref: _, meta: _, clock: _)] = Swarm.Registry.get_by_meta(:mfa, {MyApp.WorkerSup, :register, []})
     right: [
              {:entry, {:test, 1}, #PID<0.359.0>,
               #Reference<0.1496879406.3479437313.42553>,
               %{mfa: {MyApp.WorkerSup, :register, []}}, {1, 1}},
              {:entry, {:test, 2}, #PID<0.360.0>,
               #Reference<0.1496879406.3479437313.42556>,
               %{mfa: {MyApp.WorkerSup, :register, []}}, {1, 1}}
            ]
     stacktrace:
       test/registry_test.exs:49: (test)

Finished in 78.4 seconds
48 tests, 1 failure

Randomized with seed 773925
```

This code change fixes this behaviour:

```
$ mix test --seed 773925

Finished in 79.0 seconds
48 tests, 0 failures

Randomized with seed 773925
```