### PR TITLE
Do not update tracker clock with registry entry clocks

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -336,7 +336,7 @@ defmodule Swarm.Tracker do
         %TrackerState{sync_node: sync_node} = state
       )
       when node(from) == sync_node do
-    info("received registry from #{sync_node}, merging #{inspect sync_clock}..")
+    info("received registry from #{sync_node}, merging..")
     new_state = sync_registry(from, sync_clock, registry, state)
     # let remote node know we've got the registry
     GenStateMachine.cast(from, {:sync_ack, self(), sync_clock, get_registry_snapshot()})


### PR DESCRIPTION
This is a follow up of https://github.com/bitwalker/swarm/pull/85

I forgot to change the handle_topology_change method which is
as far as I can tell also the root cause for
https://github.com/bitwalker/swarm/issues/106