### PR TITLE
Discard pending sync request from sync_node

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -545,6 +545,15 @@ defmodule Swarm.Tracker do
     {:next_state, :tracking, %{state | sync_node: nil, sync_ref: nil}}
   end
 
+  defp resolve_pending_sync_requests(
+         %TrackerState{sync_node: sync_node, pending_sync_reqs: [pid | pending]} = state
+       )
+       when sync_node == node(pid) do
+    info("discarding sync_node from pending_sync_reqs")
+
+    resolve_pending_sync_requests(%{state | pending_sync_reqs: pending})
+  end
+
   defp resolve_pending_sync_requests(%TrackerState{pending_sync_reqs: [pid | pending]} = state) do
     pending_node = node(pid)
     # Remove monitoring of the previous sync node


### PR DESCRIPTION
At [Talkdesk](https://github.com/Talkdesk) we've stumbled at #91 and after an initial analysis using [swarm-deadlock-repro](https://github.com/kzemek/swarm-deadlock-repro) we've found that the issue occurred when a node contains a pending sync request from the `sync_node`.

This PR proposes a solution that consist on discarding pending sync request from the `sync_node`. Although I lack some context regarding the Swarm implementation I ran some tests using this approach and it untangled the node synchronization.

Execution logs of the issue:
https://gist.github.com/miguelfteixeira/1e587dadff718ad73c34011308730409

Diagram from the execution logs:
![lock_on_awaiting_sync_ack](https://user-images.githubusercontent.com/71837/49749137-66d47780-fc9f-11e8-863c-dbae0cd202f1.png)
