### PR TITLE
Improve performance of logging

### DIFF
--- a/lib/swarm/logger.ex
+++ b/lib/swarm/logger.ex
@@ -1,28 +1,9 @@
 defmodule Swarm.Logger do
   @moduledoc false
-  require Logger
 
   @doc """
-  Log a debugging message
+  Formats a log message to include info on which node swarm is running on
   """
-  @spec debug(String.t()) :: :ok
-  def debug(message), do: Logger.debug("[swarm on #{Node.self()}] #{message}")
-
-  @doc """
-  Log a warning message
-  """
-  @spec warn(String.t()) :: :ok
-  def warn(message), do: Logger.warn("[swarm on #{Node.self()}] #{message}")
-
-  @doc """
-  Log an info message
-  """
-  @spec info(String.t()) :: :ok
-  def info(message), do: Logger.info("[swarm on #{Node.self()}] #{message}")
-
-  @doc """
-  Log an error message
-  """
-  @spec error(String.t()) :: :ok
-  def error(message), do: Logger.error("[swarm on #{Node.self()}] #{message}")
+  @spec format(String.t()) :: String.t()
+  def format(message), do: "[swarm on #{Node.self()}] #{message}"
 end

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -14,6 +14,7 @@ defmodule Swarm.Tracker do
   @default_anti_entropy_interval 5 * 60_000
 
   import Swarm.Entry
+  require Logger
   require Swarm.Registry
   alias Swarm.IntervalTreeClock, as: Clock
   alias Swarm.Registry
@@ -110,7 +111,7 @@ defmodule Swarm.Tracker do
     {current_state, _arity} = __CALLER__.function
 
     quote do
-      Swarm.Logger.debug("[tracker:#{unquote(current_state)}] #{unquote(msg)}")
+      Logger.debug(Swarm.Logger.format("[tracker:#{unquote(current_state)}] #{unquote(msg)}"))
     end
   end
 
@@ -118,7 +119,7 @@ defmodule Swarm.Tracker do
     {current_state, _arity} = __CALLER__.function
 
     quote do
-      Swarm.Logger.info("[tracker:#{unquote(current_state)}] #{unquote(msg)}")
+      Logger.info(Swarm.Logger.format("[tracker:#{unquote(current_state)}] #{unquote(msg)}"))
     end
   end
 
@@ -126,7 +127,7 @@ defmodule Swarm.Tracker do
     {current_state, _arity} = __CALLER__.function
 
     quote do
-      Swarm.Logger.warn("[tracker:#{unquote(current_state)}] #{unquote(msg)}")
+      Logger.warn(Swarm.Logger.format("[tracker:#{unquote(current_state)}] #{unquote(msg)}"))
     end
   end
 
@@ -134,7 +135,7 @@ defmodule Swarm.Tracker do
     {current_state, _arity} = __CALLER__.function
 
     quote do
-      Swarm.Logger.error("[tracker:#{unquote(current_state)}] #{unquote(msg)}")
+      Logger.error(Swarm.Logger.format("[tracker:#{unquote(current_state)}] #{unquote(msg)}"))
     end
   end
 


### PR DESCRIPTION
The way that logging is currently done means that even though debug logging isn't turned on the log message is still evaluated and thus the inspect function is called. This has a big impact on how long it takes to sync since inspect is very slow.

This PR changes how logging is done to ensure log messages are only evaluated if they are actually needed.

Below I include two screenshots of the impact of the changes introduced in this PR on avg and max time spent syncing, overall it's around a factor of 20:

**Before changes:**
![image](https://user-images.githubusercontent.com/574189/53685010-3f78ce00-3d15-11e9-883d-14d53921d0b7.png)



**After change:**
![image](https://user-images.githubusercontent.com/574189/53684867-59b1ac80-3d13-11e9-8019-07ce94252760.png)
