### PR TITLE
Switch from :track and :untrack events, which are unrecognized, to replica events which *are*  recognized

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1593,7 +1593,9 @@ defmodule Swarm.Tracker do
          entry(name: rname, pid: rpid),
          state
        ) do
+    GenStateMachine.cast({__MODULE__, remote_node}, {:untrack, rpid})
     send(rpid, {:swarm, :die})
+    GenStateMachine.cast({__MODULE__, remote_node}, {:track, rname, lpid, lmeta})
     state
   end
 

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1593,9 +1593,7 @@ defmodule Swarm.Tracker do
          entry(name: rname, pid: rpid),
          state
        ) do
-    GenStateMachine.cast({__MODULE__, remote_node}, {:untrack, rpid})
     send(rpid, {:swarm, :die})
-    GenStateMachine.cast({__MODULE__, remote_node}, {:track, rname, lpid, lmeta})
     state
   end
 

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1593,9 +1593,9 @@ defmodule Swarm.Tracker do
          entry(name: rname, pid: rpid),
          state
        ) do
-    GenStateMachine.cast({__MODULE__, remote_node}, {:untrack, rpid})
+    GenStateMachine.cast({__MODULE__, remote_node}, {:event, self(), state.clock, {:untrack, rpid}})
     send(rpid, {:swarm, :die})
-    GenStateMachine.cast({__MODULE__, remote_node}, {:track, rname, lpid, lmeta})
+    GenStateMachine.cast({__MODULE__, remote_node}, {:event, self(), state.clock, {:track, rname, lpid, lmeta}})
     state
   end
 


### PR DESCRIPTION
Closes https://github.com/bitwalker/swarm/issues/127

I'm really not sure if this is correct or not, but the tests seem to pass and the "unrecognized cast" messages are now gone. I'm not sure whether it actually fixes anything or changes any behavior.