### PR TITLE
Fix for worker names that do not implement String.Chars

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1181,7 +1181,7 @@ defmodule Swarm.Tracker do
     |> case do
       :undefined ->
         # Worker was already removed from registry -> do nothing
-        debug "The node #{worker_name} was not found in the registry"
+        debug "The node #{inspect worker_name} was not found in the registry"
       entry(name: name, pid: pid, meta: %{mfa: _mfa} = meta) = obj ->
         case Strategy.remove_node(state.strategy, state.self) |> Strategy.key_to_node(name) do
           {:error, {:invalid_ring, :no_nodes}} ->


### PR DESCRIPTION
I got the following crash when adding another node to the cluster:

```
protocol String.Chars not implemented for {:livechat, "room_name"} of type Tuple. This protocol is implemented for the following type(s): Cldr.Calendar.Duration, Cldr.Unit, Money, Postgrex.Copy, Postgrex.Query, Decimal, URI, BitString, Float, NaiveDateTime, Date, DateTime, Version.Requirement, Version, Atom, List, Time, Integer
```

![Backtrace](https://user-images.githubusercontent.com/5446019/81042696-fa1fd580-8eb0-11ea-8947-6e7a38b591c8.png)
