### PR TITLE
Log using anonymous functions so work is dropped if not needed

### DIFF
--- a/test/tracker_replica_event_test.exs
+++ b/test/tracker_replica_event_test.exs
@@ -103,7 +103,6 @@ defmodule Swarm.TrackerReplicaEventTests do
 
   test "handle_replica_event :track with conflicting pid and local clock dominates should ignore the event",
        %{name: name, pid: pid, meta: meta, lclock: lclock, rclock: rclock} do
-
     lclock = Clock.event(lclock)
     send_replica_event(lclock, {:track, name, pid, meta})
 
@@ -208,7 +207,7 @@ defmodule Swarm.TrackerReplicaEventTests do
 
     assert entry(name: _, pid: ^pid, ref: _, meta: ^meta, clock: _) = Registry.get_by_name(name)
   end
-  
+
   test "handle_replica_event :update_meta when conflict should merge the meta data", %{
     name: name,
     pid: pid,


### PR DESCRIPTION
Fixes issue #142

Here is an example of the beam_code from current master using elixir 1.10.3:

```
                    try case erlang:apply(_m@1, _f@1, _a@1) of
                            {ok, _pid@1} ->
                                'Elixir.Swarm.Logger':debug(<<"[tracker:",
                                                              case do_track of
                                                                  _@6
                                                                      when
                                                                        erlang:is_binary(_@6) ->
                                                                      _@6;
                                                                  _@6 ->
                                                                      'Elixir.String.Chars':to_string(_@6)
                                                              end/binary,
                                                              "] ",
                                                              case <<"started ",
                                                                     ('Elixir.Kernel':inspect(_name@1))/binary,
                                                                     " on ",
                                                                     case
                                                                         _current_node@1
                                                                         of
                                                                         _@7
                                                                             when
                                                                               erlang:is_binary(_@7) ->
                                                                             _@7;
                                                                         _@7 ->
                                                                             'Elixir.String.Chars':to_string(_@7)
                                                                     end/binary>>
                                                                  of
                                                                  _@8
                                                                      when
                                                                        erlang:is_binary(_@8) ->
                                                                      _@8;
                                                                  _@8 ->
                                                                      'Elixir.String.Chars':to_string(_@8)
                                                              end/binary>>),
```

Here is an example with the changes proposed:

```
                    try case erlang:apply(_m@1, _f@1, _a@1) of
                            {ok, _pid@1} ->
                                case 'Elixir.Logger':'__should_log__'(debug,
                                                                      'Elixir.Swarm.Tracker')
                                    of
                                    nil -> ok;
                                    _@8 ->
                                        'Elixir.Logger':'__do_log__'(_@8,
                                                                     fun () ->
                                                                             'Elixir.Swarm.Logger':format(<<"[tracker:",
                                                                                                            case
                                                                                                                do_track
                                                                                                                of
                                                                                                                _@9
                                                                                                                    when
                                                                                                                      erlang:is_binary(_@9) ->
                                                                                                                    _@9;
                                                                                                                _@9 ->
                                                                                                                    'Elixir.String.Chars':to_string(_@9)
                                                                                                            end/binary,
                                                                                                            "] ",
                                                                                                            case
                                                                                                                fun
                                                                                                                    () ->
                                                                                                                        <<"started ",
                                                                                                                          ('Elixir.Kernel':inspect(_name@1))/binary,
                                                                                                                          " on ",
                                                                                                                          case
                                                                                                                              _current_node@1
                                                                                                                              of
                                                                                                                              _@10
                                                                                                                                  when
                                                                                                                                    erlang:is_binary(_@10) ->
                                                                                                                                  _@10;
                                                                                                                              _@10 ->
                                                                                                                                  'Elixir.String.Chars':to_string(_@10)
                                                                                                                          end/binary>>
                                                                                                                end()
                                                                                                                of
                                                                                                                _@11
                                                                                                                    when
                                                                                                                      erlang:is_binary(_@11) ->
                                                                                                                    _@11;
                                                                                                                _@11 ->
                                                                                                                    'Elixir.String.Chars':to_string(_@11)
                                                                                                            end/binary>>)
                                                                     end,
```

As you can see they are now wrapped inside a `__should_log__` function which will not execute the masses of work this log message creates unnecessarily 